### PR TITLE
chore: bump GitHub Actions to Node.js 24-compatible versions (PLA-81)

### DIFF
--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build & join docs 🏗
         run: ./hack/build-docs.sh
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -42,4 +42,4 @@ jobs:
           path: publish
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Closes PLA-81

## Summary

Fixes the Node.js 20 deprecation warning on GitHub Actions runners (forced default June 16 2026, removed Sep 16 2026).

## Actions bumped

| Action | From | To |
|--------|------|----|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/configure-pages` | `@v5` | `@v6` |
| `actions/deploy-pages` | `@v4` | `@v5` |

All drop-in compatible. Changelog notes: https://linear.app/ankorstore/document/pla-20-nodejs-20-action-upgrade-tracker-fdea2772f679

Tracked in: https://linear.app/ankorstore/issue/PLA-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)